### PR TITLE
Add E-REDES datasource directory structure

### DIFF
--- a/Datasources/E-REDES/ERedesDataPrepare.py
+++ b/Datasources/E-REDES/ERedesDataPrepare.py
@@ -1,0 +1,8 @@
+"""Data preparation script for E-REDES exports.
+
+This module is a placeholder for converting the E-REDES `.xlsx` export file
+into the CSV format expected by the generic import tools.
+"""
+
+if __name__ == "__main__":
+    raise NotImplementedError("E-REDES data preparation not yet implemented.")

--- a/Datasources/E-REDES/README.md
+++ b/Datasources/E-REDES/README.md
@@ -1,0 +1,8 @@
+# Energy provider: E-REDES
+
+This directory will contain the tooling to convert data exported from E-REDES
+into CSV files suitable for the generic import scripts used by Home Assistant.
+
+* `ERedesDataPrepare.py` – conversion script (to be implemented).
+* `Sample files/` – place sample `.xlsx` exports here for development.
+* `tests/` – automated tests for the conversion script.

--- a/Datasources/E-REDES/Sample files/README.md
+++ b/Datasources/E-REDES/Sample files/README.md
@@ -1,0 +1,4 @@
+# Sample files for E-REDES
+
+Place example `.xlsx` files exported from E-REDES in this directory.
+These files will be used for development and testing of the data preparation scripts.

--- a/Datasources/E-REDES/tests/test_ERedes.py
+++ b/Datasources/E-REDES/tests/test_ERedes.py
@@ -1,0 +1,6 @@
+"""Placeholder tests for the E-REDES data preparation module."""
+
+
+def test_placeholder():
+    """Temporary test to ensure test discovery succeeds."""
+    assert True


### PR DESCRIPTION
## Summary
- scaffold E-REDES datasource with README, placeholder conversion script, sample-file folder and tests

## Testing
- `pytest` *(fails: Script /workspace/Home-Assistant-Import-Energy-Data/Datasources/Zonneplan/ZonneplanDataPrepare.py exited with 1)*


------
https://chatgpt.com/codex/tasks/task_e_68c5ac320d3c83269fc9a64cfa215cec