### PR TITLE
feat: handle dynamic header row in E-REDES import

### DIFF
--- a/Datasources/E-REDES/README.md
+++ b/Datasources/E-REDES/README.md
@@ -5,6 +5,8 @@ This directory contains the tooling to convert data exported from
 generic import scripts used by Home Assistant.
 
 * `ERedesDataPrepare.py` – conversion script which transforms an E‑REDES
-  `.xlsx` export into the expected two‑column CSV format.
+  `.xlsx` export into the expected two‑column CSV format.  The script
+  automatically locates the header row, allowing any non‑essential rows above
+  the data to be removed without breaking the conversion.
 * `Sample files/` – example `.xlsx` export and the resulting CSV used in tests.
 * `tests/` – automated tests for the conversion script.

--- a/Datasources/E-REDES/tests/test_ERedes.py
+++ b/Datasources/E-REDES/tests/test_ERedes.py
@@ -1,5 +1,9 @@
 """Integration tests for the E-REDES data preparation script."""
 
+from pathlib import Path
+
+import pandas as pd
+
 from tests.helpers import run_commands
 
 
@@ -11,4 +15,26 @@ COMMANDS = [
 def test_commands(repo_root):
     """Execute the script and verify generated CSV against the sample."""
     run_commands(repo_root, COMMANDS)
+
+
+def test_header_at_row_one(repo_root):
+    """Header row may appear at the very top if preamble rows are removed."""
+
+    source_dir = Path(__file__).resolve().parent.parent
+    sample_dir = source_dir / "Sample files"
+    original = sample_dir / "e-redes-sample.xlsx"
+    modified = sample_dir / "e-redes-sample-row1.xlsx"
+
+    # Create a new export where the header is the first row
+    df = pd.read_excel(original, header=7)
+    df.to_excel(modified, index=False)
+
+    try:
+        run_commands(
+            repo_root,
+            [("ERedesDataPrepare.py", ["-y", f"Sample files/{modified.name}"])],
+        )
+    finally:
+        if modified.exists():
+            modified.unlink()
 


### PR DESCRIPTION
## Summary
- allow E-REDES converter to locate header row dynamically and support inline string cells
- document and test header-at-row1 scenario

## Testing
- `pytest Datasources/E-REDES/tests/test_ERedes.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5da3cd38c8326b749eeed24f727c8