### PR TITLE
Revert DataPrepareEngine output directory change

### DIFF
--- a/Datasources/DataPrepareEngine.py
+++ b/Datasources/DataPrepareEngine.py
@@ -520,23 +520,18 @@ def generateImportDataFiles(
     # Prepare the data
     dataFrame = prepareData(dataFrame)
 
-    # Determine output directory: same as the first input file
-    outputDir = os.path.dirname(fileNames[0]) or "."
-
     # Create the output files
     for outputFile in outputFiles:
         # Check if we have to generate a specific output file
         if outputFileName is None or outputFile.outputFileName == outputFileName:
             # Generate the import data file and ensure dataFrame is not modified between definitions
-            outputPath = os.path.join(
-                outputDir,
-                f"{prefix}_{outputFile.outputFileName}"
-                if prefix
-                else outputFile.outputFileName,
-            )
             generateImportDataFile(
                 dataFrame.copy(),
-                outputPath,
+                (
+                    f"{prefix}_{outputFile.outputFileName}"
+                    if prefix
+                    else outputFile.outputFileName
+                ),
                 outputFile.valueColumnName,
                 outputFile.dataFilters,
                 outputFile.intervalMode,
@@ -592,7 +587,7 @@ Notes:
     args = parser.parse_args()
 
     print(
-        "The files will be prepared in the same directory as the input files. Any previous files will be overwritten!\n"
+        "The files will be prepared in the current directory. Any previous files will be overwritten!\n"
     )
 
     # proceed automatically if --yes was passed


### PR DESCRIPTION
## Summary
- revert `Datasources/DataPrepareEngine.py` to the upstream version that writes generated CSV files to the current working directory instead of the input file directory
- restore the user-facing prompt text about where files are written

## Testing
- `pytest` *(fails: generated CSV outputs do not match provided samples for several datasources and the Solax script exits because the optional xlrd dependency cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c881a6d9e48326be7173786728fe71